### PR TITLE
Sets pry-meta gem just to ruby >= 2.0 platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 gemspec
 
-gem "pry-meta", platforms: :ruby
+gem "pry-meta", platforms: [:ruby_20, :ruby_21]


### PR DESCRIPTION
pry-meta has a dependency with `byebug` gem that doesn't works with ruby 1.9.3