### PR TITLE
To Keep the initial configuration when there are new threads

### DIFF
--- a/lib/pagseguro.rb
+++ b/lib/pagseguro.rb
@@ -85,7 +85,7 @@ module PagSeguro
 
   # The configuration intance for the thread
   def self.configuration
-    Thread.current[:pagseguro_config] ||= PagSeguro::Config.new
+    Thread.current[:pagseguro_config] ||= solve_configuration
   end
 
   # Set the global configuration.
@@ -107,5 +107,18 @@ module PagSeguro
   # The site url.
   def self.site_url(path)
     File.join(root_uri(:site), path)
+  end
+
+  private
+  def self.solve_configuration
+    other_thread && main_configuration ? main_configuration.clone : PagSeguro::Config.new
+  end
+
+  def self.other_thread
+    Thread.main != Thread.current
+  end 
+
+  def self.main_configuration
+    Thread.main[:pagseguro_config]
   end
 end

--- a/spec/pagseguro/pagseguro_spec.rb
+++ b/spec/pagseguro/pagseguro_spec.rb
@@ -31,6 +31,11 @@ describe PagSeguro do
       end
       thread.join
 
+      thread_2 = Thread.new do
+        expect(PagSeguro.receiver_email).to eql("RECEIVER_EMAIL")
+      end
+      thread_2.join
+
       expect(PagSeguro.receiver_email).to eql("RECEIVER_EMAIL")
     end
   end


### PR DESCRIPTION
When I run the application with multi threads, the initial configuration is missed.