### PR TITLE
Finish rename of…

### DIFF
--- a/examples/boleto_transaction_request.rb
+++ b/examples/boleto_transaction_request.rb
@@ -42,7 +42,7 @@ payment.shipping = {
 # payment.extra_params << { senderBirthDate: '07/05/1981' }
 
 puts "=> REQUEST"
-puts PagSeguro::TransactionRequest::Serializer.new(payment).to_params
+puts PagSeguro::TransactionRequest::RequestSerializer.new(payment).to_params
 puts
 
 transaction = payment.create

--- a/examples/credit_card_transaction_request.rb
+++ b/examples/credit_card_transaction_request.rb
@@ -70,7 +70,7 @@ payment.installment = {
 # payment.extra_params << { senderBirthDate: '07/05/1981' }
 
 puts "=> REQUEST"
-puts PagSeguro::TransactionRequest::Serializer.new(payment).to_params
+puts PagSeguro::TransactionRequest::RequestSerializer.new(payment).to_params
 puts
 
 transaction = payment.create

--- a/examples/online_debit_transaction.rb
+++ b/examples/online_debit_transaction.rb
@@ -46,7 +46,7 @@ payment.bank = {
 # payment.extra_params << { senderBirthDate: '07/05/1981' }
 
 puts "=> REQUEST"
-puts PagSeguro::TransactionRequest::Serializer.new(payment).to_params
+puts PagSeguro::TransactionRequest::RequestSerializer.new(payment).to_params
 puts
 
 transaction = payment.create


### PR DESCRIPTION
Finish rename of `PagSeguro::TransactionRequest::Serializer` to `PagSeguro::TransactionRequest::ResponseSerializer`.

This rename was started on c95f04210243ba9fd0401916540458f15c43a7c2