### PR TITLE
Update examples/authorization.rb to use AuthorizationRequest instead of Authorization

### DIFF
--- a/examples/authorization.rb
+++ b/examples/authorization.rb
@@ -11,17 +11,15 @@ require_relative "boot"
 # or
 # credentials = PagSeguro::ApplicationCredentials.new("app45", "1D4738")
 options = {
-  credentials: credentials,
   permissions: [:searches, :notifications],
   notification_url: 'foo.com.br',
   redirect_url: 'bar.com.br'
 }
 
-response = PagSeguro::Authorization.new(options).authorize
-
-puts "=> Response"
-puts response.code
-puts response.created_at
-
-puts "Use this link to confirm authorizations:"
-puts "  link: #{response.url}"
+authorization_request = PagSeguro::AuthorizationRequest.new(options)
+if authorization_request.create
+  print "Use this link to confirm authorizations: "
+  puts authorization_request.url
+else
+  puts authorization_request.errors.join("\n")
+end

--- a/lib/pagseguro/authorization_request.rb
+++ b/lib/pagseguro/authorization_request.rb
@@ -38,7 +38,7 @@ module PagSeguro
     # Post and create an Authorization.
     # Return Boolean.
     def create
-      request = Request.post('authorizations/request', params)
+      request = Request.post('authorizations/request', 'v2', params)
       response = Response.new(request)
       update_attributes(response.serialize)
 
@@ -47,7 +47,7 @@ module PagSeguro
 
     # URL to confirm authorization after create one.
     def url
-      PagSeguro.site_url("authorization/request.jhtml?code=#{code}") if code
+      PagSeguro.site_url("v2/authorization/request.jhtml?code=#{code}") if code
     end
 
     def errors

--- a/spec/pagseguro/authorization_request_spec.rb
+++ b/spec/pagseguro/authorization_request_spec.rb
@@ -29,7 +29,7 @@ describe PagSeguro::AuthorizationRequest do
 
     before do
       expect(PagSeguro::Request).to receive(:post)
-        .with("authorizations/request", params)
+        .with("authorizations/request", 'v2', params)
         .and_return(request)
       expect(PagSeguro::AuthorizationRequest::Response).to receive(:new)
         .with(request)


### PR DESCRIPTION
Update `examples/authorization.rb` to use `AuthorizationRequest` instead of `Authorization`.

The feature to create a authorization was changed to `AuthorizationRequest`.

Also `AuthorizationRequest` needed to be updated.