### PR TITLE
2.4.0 dev update Transaction Cancelation

### DIFF
--- a/examples/transaction/transaction_cancellation.rb
+++ b/examples/transaction/transaction_cancellation.rb
@@ -3,11 +3,11 @@ require_relative "boot"
 cancellation = PagSeguro::TransactionCancellation.new
 cancellation.transaction_code = "AFB8FCF29496401681257C1ECE3A98FF"
 
-response = cancellation.register
+cancellation.register
 
-if response.errors.any?
-  puts response.errors.join("\n")
+if cancellation.errors.any?
+  puts cancellation.errors.join("\n")
 else
   puts "=> CANCELLATION RESPONSE"
-  puts response.result
+  puts cancellation.result
 end


### PR DESCRIPTION
Update Transaction Cancelation example.

`register` method returns a boolean.