### PR TITLE
Fixes to PagSeguro::Transaction::Search* serializers.

### DIFF
--- a/lib/pagseguro/transaction.rb
+++ b/lib/pagseguro/transaction.rb
@@ -192,6 +192,11 @@ module PagSeguro
       attrs.each { |name, value| send("#{name}=", value) }
     end
 
+    # Serialize the XML object.
+    def self.load_from_xml(xml) # :nodoc:
+      new Serializer.new(xml).serialize
+    end
+
     private
     def self.api_version
       'v3'

--- a/lib/pagseguro/transaction/search.rb
+++ b/lib/pagseguro/transaction/search.rb
@@ -27,7 +27,7 @@ module PagSeguro
     # call. Remember that this will perform an additional HTTP request.
     def transactions
       xml do |xml|
-        xml.css("transactionSearchResult transaction").map do |node|
+        xml.css("transactionSearchResult > transactions > transaction").map do |node|
           Transaction.load_from_xml(node)
         end
       end

--- a/lib/pagseguro/transaction/serializer.rb
+++ b/lib/pagseguro/transaction/serializer.rb
@@ -32,13 +32,13 @@ module PagSeguro
 
       private
       def serialize_general(data)
-        data[:code] = xml.css("transaction > code").text
-        data[:reference] = xml.css("transaction > reference").text
-        data[:type_id] = xml.css("transaction > type").text
-        data[:payment_link] = xml.css("transaction > paymentLink").text
-        data[:status] = xml.css("transaction > status").text
+        data[:code] = xml.at_css("code").text
+        data[:reference] = xml.css("reference").text
+        data[:type_id] = xml.at_css("type").text
+        data[:payment_link] = xml.css("paymentLink").text
+        data[:status] = xml.at_css("status").text
 
-        cancellation_source = xml.css("transaction > cancellationSource")
+        cancellation_source = xml.css("cancellationSource")
         data[:cancellation_source] = cancellation_source.text if cancellation_source.any?
 
         data[:payment_method] = {

--- a/spec/pagseguro/request_spec.rb
+++ b/spec/pagseguro/request_spec.rb
@@ -11,10 +11,6 @@ describe PagSeguro::Request do
   context "POST request" do
     before do
       FakeWeb.register_uri :post, %r[.+], body: "BODY"
-      PagSeguro.configure do |config|
-        config.app_id = nil
-        config.app_key = nil
-      end
     end
 
     it "includes credentials" do

--- a/spec/pagseguro/transaction/response_spec.rb
+++ b/spec/pagseguro/transaction/response_spec.rb
@@ -64,7 +64,7 @@ describe PagSeguro::Transaction::Response do
     let(:parsed_xml) { Nokogiri::XML(raw_xml) }
 
     context "when request succeeds" do
-      let(:raw_xml) { File.read("./spec/fixtures/transactions/status_history.xml") }
+      let(:raw_xml) { File.read("./spec/fixtures/transactions/success.xml") }
 
       it "returns a transaction" do
         expect(subject.serialize).to be_a(PagSeguro::Transaction)

--- a/spec/pagseguro/transaction/search/search_abandoned_spec.rb
+++ b/spec/pagseguro/transaction/search/search_abandoned_spec.rb
@@ -1,42 +1,55 @@
 require 'spec_helper'
 
 describe PagSeguro::SearchAbandoned do
+  subject do
+    PagSeguro::SearchAbandoned.new("transactions/abandoned", options, 1)
+  end
+
+  let(:source) { File.read("./spec/fixtures/transactions/search.xml") }
+  let(:body) { Nokogiri::XML(source) }
+
   describe 'it searches abandoned transactions' do
-    let(:options) { { starts_at: Time.now, ends_at: Time.now, page: 1, per_page: 10 } }
-    let(:search) { PagSeguro::SearchAbandoned.new("transactions/abandoned", options, 1) }
-    let(:source) { File.read("./spec/fixtures/transactions/search.xml") }
-    let(:xml) { Nokogiri::XML(source) }
-    let(:response) { double(:response, data: xml, unauthorized?: false, bad_request?: false) }
+    before do
+      FakeWeb.register_uri :get,
+        %r{https://ws.pagseguro.uol.com.br/v2/transactions/abandoned.*finalDate=2015-11-12T16%3A59.*initialDate=2015-11-12T15%3A34.*page=1},
+        body: body
+    end
+
+    let(:options) do
+      {
+        starts_at: Time.new(2015, 11, 12, 15, 34),
+        ends_at: Time.new(2015, 11, 12, 16, 59),
+        page: 1,
+        per_page: 10
+      }
+    end
 
     describe 'the search abandoned' do
-      before do
-        FakeWeb.register_uri :get, %r[#{PagSeguro.api_url('v2/transactions/abandoned')}.*],
-          body: xml
-      end
-
-      let(:transaction) { double(:transaction) }
-
       it 'returns an array of transactions' do
-        expect(PagSeguro::Transaction).to receive(:load_from_xml).exactly(2)
-          .times
-          .and_return(transaction)
-        expect(search.transactions).to eq([transaction, transaction])
+        expect(subject.transactions.size).to eq(2)
       end
+    end
+  end
 
-      it 'returns an array whith given credentials' do
-        options_with_credentials = {
-          credentials: PagSeguro::ApplicationCredentials.new('APP_ID', 'APP_KEY')
-        }.merge(options)
+  describe 'it searches abandoned transactions using credentials' do
+    before do
+      FakeWeb.register_uri :get,
+        %r{https://ws.pagseguro.uol.com.br/v2/transactions/abandoned.*appId=APP_ID.*appKey=APP_KEY.*finalDate=2015-11-12T16%3A59.*initialDate=2015-11-12T15%3A34.*},
+        body: body
+    end
 
-        expect(PagSeguro::Transaction).to receive(:load_from_xml)
-          .exactly(2)
-          .times
-          .and_return(transaction)
+    let(:options) do
+      {
+        starts_at: Time.new(2015, 11, 12, 15, 34),
+        ends_at: Time.new(2015, 11, 12, 16, 59),
+        page: 1,
+        per_page: 10,
+        credentials: PagSeguro::ApplicationCredentials.new('APP_ID', 'APP_KEY')
+      }
+    end
 
-        expect(
-          PagSeguro::SearchAbandoned.new('transactions/abandoned', options_with_credentials, 1).transactions
-        ).to eq([transaction, transaction])
-      end
+    it 'returns an array with given credentials' do
+      expect(subject.transactions.size).to eq(2)
     end
   end
 end

--- a/spec/pagseguro/transaction/search/search_by_reference_spec.rb
+++ b/spec/pagseguro/transaction/search/search_by_reference_spec.rb
@@ -1,26 +1,21 @@
 require 'spec_helper'
 
 describe PagSeguro::SearchByReference do
-  describe 'it searches transactions by reference' do
-    let(:options) { { reference: "ref1234" } }
-    let(:search) { PagSeguro::SearchByReference.new("transactions", options, 1) }
-    let(:source) { File.read("./spec/fixtures/transactions/search.xml") }
-    let(:xml) { Nokogiri::XML(source) }
-    let(:response) { double(:response, data: xml, unauthorized?: false, bad_request?: false) }
+  subject do
+    PagSeguro::SearchByReference.new("transactions", options, 1)
+  end
 
-    describe 'the search by reference' do
-      before do
-        FakeWeb.register_uri :get, %r[#{PagSeguro.api_url('v3/transactions')}.*], body: xml
-      end
+  before do
+    FakeWeb.register_uri :get,
+      %r{https://ws.pagseguro.uol.com.br/v3/transactions.*reference=ref1234.*},
+      body: body
+  end
 
-      let(:transaction) { double(:transaction) }
+  let(:options) { { reference: "ref1234" } }
+  let(:source) { File.read("./spec/fixtures/transactions/search.xml") }
+  let(:body) { Nokogiri::XML(source) }
 
-      it 'returns an array of transactions' do
-        expect(PagSeguro::Transaction).to receive(:load_from_xml).exactly(2)
-          .times
-          .and_return(transaction)
-        expect(search.transactions).to eq([transaction, transaction])
-      end
-    end
+  it 'searches transactions by reference' do
+    expect(subject.transactions.size).to eq(2)
   end
 end

--- a/spec/pagseguro/transaction/search_spec.rb
+++ b/spec/pagseguro/transaction/search_spec.rb
@@ -29,13 +29,8 @@ describe PagSeguro::Search do
     end
 
     describe '#transactions' do
-      let(:transaction) { double(:transaction) }
-
       it 'returns an array of transactions' do
-        expect(PagSeguro::Transaction).to receive(:load_from_xml).exactly(2)
-          .times
-          .and_return(transaction)
-        expect(search.transactions).to eq([transaction, transaction])
+        expect(search.transactions.size).to eq(2)
       end
     end
 

--- a/spec/pagseguro/transaction/serializer_spec.rb
+++ b/spec/pagseguro/transaction/serializer_spec.rb
@@ -5,7 +5,7 @@ describe PagSeguro::Transaction::Serializer do
   context "for existing transactions" do
     let(:source) { File.read("./spec/fixtures/transactions/success.xml") }
     let(:xml) { Nokogiri::XML(source) }
-    let(:serializer) { described_class.new(xml.css("transaction")) }
+    let(:serializer) { described_class.new(xml.css("transaction").first) }
     subject(:data) { serializer.serialize }
 
     it { expect(data).to include(created_at: Time.parse("2013-05-01T01:40:27.000-03:00")) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,4 +25,13 @@ RSpec.configure do |config|
     load "./lib/pagseguro.rb"
     FakeWeb.clean_registry
   end
+
+  config.after do
+    PagSeguro.configure do |config|
+      config.app_id = nil
+      config.app_key = nil
+      config.email = nil
+      config.token = nil
+    end
+  end
 end


### PR DESCRIPTION
Fixes to PagSeguro::Transaction::Search* serializers.

Also adds after to specs to clear authentications.