### PR TITLE
Add forbidden to Errors.

### DIFF
--- a/lib/pagseguro/errors.rb
+++ b/lib/pagseguro/errors.rb
@@ -21,6 +21,7 @@ module PagSeguro
     private
     def process(response)
       @messages << error_message(:unauthorized, "Unauthorized") if response.unauthorized?
+      @messages << error_message(:forbidden, "Forbidden") if response.forbidden?
       @messages << error_message(:not_found, "Not found") if response.not_found?
 
       response.data.css("errors > error").each do |error|

--- a/lib/pagseguro/transaction.rb
+++ b/lib/pagseguro/transaction.rb
@@ -81,8 +81,7 @@ module PagSeguro
     def self.find_status_history(code)
       request = send_request("transactions/#{code}/statusHistory")
       collection = StatusCollection.new
-      response = Response.new(request, collection)
-      response.serialize_statuses
+      Response.new(request, collection).serialize_statuses
 
       collection
     end

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -2,6 +2,7 @@ pt-BR:
   pagseguro:
     errors:
       unauthorized: "Não autorizado."
+      forbidden: "Proibido."
       not_found: "Não encontrado."
       "10001": "O parâmetro email deve ser informado."
       "10002": "O parâmetro token deve ser informado."

--- a/spec/pagseguro/errors_spec.rb
+++ b/spec/pagseguro/errors_spec.rb
@@ -3,7 +3,15 @@ require "spec_helper"
 
 describe PagSeguro::Errors do
   let(:response) { double }
-  let(:http_response) { double(:http_response, unauthorized?: true, bad_request?: false, not_found?: false) }
+  let(:http_response) do
+    double(
+      :http_response,
+      unauthorized?: true,
+      bad_request?: false,
+      not_found?: false,
+      forbidden?: false,
+    )
+  end
 
   context "when have no response" do
     it "returns errors" do
@@ -16,7 +24,12 @@ describe PagSeguro::Errors do
     subject(:errors) { PagSeguro::Errors.new(response) }
 
     before do
-      allow(response).to receive_messages(unauthorized?: true, bad_request?: false, not_found?: false)
+      allow(response).to receive_messages(
+        unauthorized?: true,
+        bad_request?: false,
+        not_found?: false,
+        forbidden?: false,
+      )
       errors.add(http_response)
     end
 
@@ -28,12 +41,34 @@ describe PagSeguro::Errors do
     subject(:errors) { PagSeguro::Errors.new(response) }
 
     before do
-      allow(response).to receive_messages(unauthorized?: true, bad_request?: false, not_found?: true)
+      allow(response).to receive_messages(
+        unauthorized?: true,
+        bad_request?: false,
+        not_found?: true,
+        forbidden?: false
+      )
       errors.add(http_response)
     end
 
     it { expect(errors).not_to be_empty }
     it { expect(errors).to include(I18n.t("pagseguro.errors.not_found")) }
+  end
+
+  context 'when forbidden' do
+    subject(:errors) { PagSeguro::Errors.new(response) }
+
+    before do
+      allow(response).to receive_messages(
+        unauthorized?: true,
+        bad_request?: false,
+        not_found?: false,
+        forbidden?: true
+      )
+      errors.add(http_response)
+    end
+
+    it { expect(errors).not_to be_empty }
+    it { expect(errors).to include(I18n.t("pagseguro.errors.forbidden")) }
   end
 
   context "when message can't be translated" do
@@ -52,7 +87,13 @@ describe PagSeguro::Errors do
     subject(:errors) { PagSeguro::Errors.new(response) }
 
     before do
-      allow(response).to receive_messages(data: xml, unauthorized?: false, bad_request?: true, not_found?: true)
+      allow(response).to receive_messages(
+        data: xml,
+        unauthorized?: false,
+        bad_request?: true,
+        not_found?: true,
+        forbidden?: false
+      )
     end
 
     it { expect(errors).to include("Sample message") }
@@ -74,7 +115,13 @@ describe PagSeguro::Errors do
     subject(:errors) { PagSeguro::Errors.new(response) }
 
     before do
-      allow(response).to receive_messages(data: xml, unauthorized?: false, bad_request?: true, not_found?: false)
+      allow(response).to receive_messages(
+        data: xml,
+        unauthorized?: false,
+        bad_request?: true,
+        not_found?: false,
+        forbidden?: false
+      )
     end
 
     it { expect(errors).to include("O parâmetro email deve ser informado.") }
@@ -97,7 +144,13 @@ describe PagSeguro::Errors do
     subject(:errors) { PagSeguro::Errors.new(response) }
 
     before do
-      allow(response).to receive_messages(data: xml, unauthorized?: false, bad_request?: true, not_found?: true)
+      allow(response).to receive_messages(
+        data: xml,
+        unauthorized?: false,
+        bad_request?: true,
+        not_found?: true,
+        forbidden?: true
+      )
       errors.add(http_response)
     end
 

--- a/spec/pagseguro/installment/response_spec.rb
+++ b/spec/pagseguro/installment/response_spec.rb
@@ -39,9 +39,12 @@ RSpec.describe PagSeguro::Installment::Response do
 
     context "when request fails" do
       before do
-        allow(http_response).to receive(:success?).and_return(false)
-        allow(http_response).to receive(:bad_request?).and_return(true)
-        allow(http_response).to receive(:not_found?).and_return(false)
+        allow(http_response).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false
+        )
       end
 
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }

--- a/spec/pagseguro/installment_spec.rb
+++ b/spec/pagseguro/installment_spec.rb
@@ -33,8 +33,11 @@ describe PagSeguro::Installment do
 
     context "when request fails" do
       before do
-        allow(request).to receive(:success?).and_return(false)
-        allow(request).to receive(:bad_request?).and_return(true)
+        allow(request).to receive_messages(
+          success?: false,
+          forbidden?: false,
+          bad_request?: true
+        )
       end
 
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }

--- a/spec/pagseguro/session/response_spec.rb
+++ b/spec/pagseguro/session/response_spec.rb
@@ -40,9 +40,14 @@ RSpec.describe PagSeguro::Session::Response do
 
     context "when request fails" do
       before do
-        allow(http_response).to receive(:success?).and_return(false)
-        allow(http_response).to receive(:bad_request?).and_return(true)
+        allow(http_response).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false
+        )
       end
+
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 
       it "change session errors" do

--- a/spec/pagseguro/session_spec.rb
+++ b/spec/pagseguro/session_spec.rb
@@ -25,8 +25,12 @@ describe PagSeguro::Session do |variable|
 
     context "when request fails" do
       before do
-        allow(request).to receive(:success?).and_return(false)
-        allow(request).to receive(:bad_request?).and_return(true)
+        allow(request).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false
+        )
       end
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 

--- a/spec/pagseguro/transaction/response_spec.rb
+++ b/spec/pagseguro/transaction/response_spec.rb
@@ -38,11 +38,15 @@ describe PagSeguro::Transaction::Response do
 
     context "when request fails" do
       before do
-        allow(http_response).to receive(:success?).and_return(false)
-        allow(http_response).to receive(:bad_request?).and_return(true)
-        allow(http_response).to receive(:not_found?).and_return(true)
-        allow(http_response).to receive(:body).and_return(raw_xml)
+        allow(http_response).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: true,
+          forbidden?: false,
+          body: raw_xml
+        )
       end
+
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 
       it "returns PagSeguro::Transaction::StatusCollection instance" do
@@ -77,11 +81,15 @@ describe PagSeguro::Transaction::Response do
 
     context "when request fails" do
       before do
-        allow(http_response).to receive(:success?).and_return(false)
-        allow(http_response).to receive(:bad_request?).and_return(true)
-        allow(http_response).to receive(:not_found?).and_return(false)
-        allow(http_response).to receive(:body).and_return(raw_xml)
+        allow(http_response).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false,
+          body: raw_xml
+        )
       end
+
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 
       it "returns the transaction" do

--- a/spec/pagseguro/transaction/search_spec.rb
+++ b/spec/pagseguro/transaction/search_spec.rb
@@ -4,7 +4,16 @@ describe PagSeguro::Search do
   let(:search) { PagSeguro::Search.new("foo", "bar", 1) }
   let(:source) { File.read("./spec/fixtures/transactions/search.xml") }
   let(:xml) { Nokogiri::XML(source) }
-  let(:response) { double(:response, data: xml, unauthorized?: false, bad_request?: false, not_found?: false) }
+  let(:response) do
+    double(
+      :response,
+      data: xml,
+      unauthorized?: false,
+      bad_request?: false,
+      not_found?: false,
+      forbidden?: false
+    )
+  end
 
   context 'when being initialized' do
     it 'initializes with passed page number' do

--- a/spec/pagseguro/transaction_cancellation_spec.rb
+++ b/spec/pagseguro/transaction_cancellation_spec.rb
@@ -35,9 +35,12 @@ describe PagSeguro::TransactionCancellation do
 
     context "when request fails" do
       before do
-        allow(http_request).to receive(:success?).and_return(false)
-        allow(http_request).to receive(:bad_request?).and_return(true)
-        allow(http_request).to receive(:not_found?).and_return(false)
+        allow(http_request).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false
+        )
       end
 
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }

--- a/spec/pagseguro/transaction_refund_spec.rb
+++ b/spec/pagseguro/transaction_refund_spec.rb
@@ -44,7 +44,17 @@ describe PagSeguro::TransactionRefund do
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 
       let :response_request do
-        double(:ResponseRequest, success?: false, unauthorized?: false, not_found?: false, bad_request?: true, data: xml_parsed, body: raw_xml, :xml? => true)
+        double(
+          :ResponseRequest,
+          success?: false,
+          unauthorized?: false,
+          not_found?: false,
+          bad_request?: true,
+          forbidden?: true,
+          xml?: true,
+          data: xml_parsed,
+          body: raw_xml
+        )
       end
 
       it "returns a PagSeguro::TransactionRefund with errors" do

--- a/spec/pagseguro/transaction_request/response_spec.rb
+++ b/spec/pagseguro/transaction_request/response_spec.rb
@@ -42,8 +42,11 @@ describe PagSeguro::TransactionRequest::Response do
 
     context "when request fails" do
       before do
-        allow(http_response).to receive(:success?).and_return(false)
-        allow(http_response).to receive(:bad_request?).and_return(true)
+        allow(http_response).to receive_messages(
+          success?: false,
+          forbidden?: false,
+          bad_request?: true
+        )
       end
 
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }

--- a/spec/pagseguro/transaction_request_spec.rb
+++ b/spec/pagseguro/transaction_request_spec.rb
@@ -99,13 +99,20 @@ describe PagSeguro::TransactionRequest do |variable|
 
     context "when request fails" do
       let :response_request do
-        double(:ResponseRequest, success?: false, unauthorized?: false, bad_request?: false, data: xml_parsed, not_found?: false, body: raw_xml, :xml? => true)
+        double(
+          :ResponseRequest,
+          success?: false,
+          unauthorized?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false,
+          xml?: true,
+          data: xml_parsed,
+          body: raw_xml
+        )
       end
 
       before do
-        allow(response_request).to receive(:success?).and_return(false)
-        allow(response_request).to receive(:bad_request?).and_return(true)
-
         allow(PagSeguro::Request).to receive(:post)
           .and_return(response_request)
       end

--- a/spec/pagseguro/transaction_spec.rb
+++ b/spec/pagseguro/transaction_spec.rb
@@ -48,10 +48,14 @@ describe PagSeguro::Transaction do
 
     context "when request fails" do
       before do
-        allow(request).to receive(:success?).and_return(false)
-        allow(request).to receive(:bad_request?).and_return(true)
-        allow(request).to receive(:not_found?).and_return(false)
+        allow(request).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false
+        )
       end
+
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 
       it "returns an instance of Transaction" do
@@ -95,10 +99,14 @@ describe PagSeguro::Transaction do
 
     context "when request fails" do
       before do
-        allow(request).to receive(:success?).and_return(false)
-        allow(request).to receive(:bad_request?).and_return(true)
-        allow(request).to receive(:not_found?).and_return(false)
+        allow(request).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false
+        )
       end
+
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 
       it "returns an instance of Transaction" do
@@ -155,9 +163,12 @@ describe PagSeguro::Transaction do
 
     context "when request fails" do
       before do
-        allow(response).to receive(:success?).and_return(false)
-        allow(response).to receive(:bad_request?).and_return(true)
-        allow(response).to receive(:not_found?).and_return(false)
+        allow(response).to receive_messages(
+          success?: false,
+          bad_request?: true,
+          not_found?: false,
+          forbidden?: false
+        )
       end
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 


### PR DESCRIPTION
When we use find_status_history with wrong code server responds with a forbidden message.