### PR TITLE
Fix checkout/create_payment_request example:

### DIFF
--- a/examples/checkout/create_payment_request.rb
+++ b/examples/checkout/create_payment_request.rb
@@ -53,7 +53,7 @@ payment.shipping = {
 # payment.extra_params << { extraAmount: '-15.00' }
 
 puts "=> REQUEST"
-puts PagSeguro::PaymentRequest::Serializer.new(payment).to_params
+puts PagSeguro::PaymentRequest::RequestSerializer.new(payment).to_params
 
 response = payment.register
 


### PR DESCRIPTION
`PagSeguro::PaymentRequest::Serializer` was renamed to `PagSeguro::PaymentRequest::RequestSerializer` in d8c54e65e6e9f7c3fd3846c08f3f478cd2dd9751