### PR TITLE
Update PagSeguro::TransactionCancellation register method.

### DIFF
--- a/lib/pagseguro/transaction_cancellation.rb
+++ b/lib/pagseguro/transaction_cancellation.rb
@@ -10,13 +10,10 @@ module PagSeguro
     attr_accessor :result
 
     # Calls the PagSeguro webservice and register the cancellation.
-    # Return boolean.
+    # Returns PagSeguro::TransactionCancellation.
     def register
-      request = Request.post("transactions/cancels", api_version, params)
-      response = Response.new(request, self)
-      response.serialize
-
-      response.success?
+      response_request = Request.post("transactions/cancels", api_version, params)
+      Response.new(response_request, self).serialize
     end
 
     # Errors object.

--- a/spec/pagseguro/transaction_cancellation_spec.rb
+++ b/spec/pagseguro/transaction_cancellation_spec.rb
@@ -20,8 +20,8 @@ describe PagSeguro::TransactionCancellation do
     context "when request succeds" do
       let(:raw_xml) { File.read("./spec/fixtures/transaction_cancellation/success.xml") }
 
-      it "returns boolean" do
-        expect(subject.register).to be_truthy
+      it "returns a PagSeguro::TransactionCancellation" do
+        expect(subject.register).to be_a_kind_of PagSeguro::TransactionCancellation
       end
 
       it "does not add errors" do


### PR DESCRIPTION
This change follows 2.2.0 code standard of serializers and related methods.