### PR TITLE
Clean up gemspec and Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source "https://rubygems.org"
 gemspec
-
-gem "pry-meta", platforms: [:ruby_20, :ruby_21]

--- a/pagseguro-oficial.gemspec
+++ b/pagseguro-oficial.gemspec
@@ -2,13 +2,12 @@
 require "./lib/pagseguro/version"
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = ">= 1.9.3"
   spec.name                  = "pagseguro-oficial"
   spec.version               = PagSeguro::VERSION
   spec.authors               = ["Nando Vieira"]
   spec.email                 = ["fnando.vieira@gmail.com"]
-  spec.description           = "Biblioteca oficial de integração PagSeguro em Ruby"
-  spec.summary               = spec.description
+  spec.summary               = "Biblioteca de integração com o PagSeguro"
+  spec.description           = "Biblioteca oficial de integração via API com o PagSeguro"
   spec.homepage              = "http://www.pagseguro.com.br"
   spec.license               = "ASL"
 
@@ -17,15 +16,16 @@ Gem::Specification.new do |spec|
   spec.test_files            = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths         = ["lib"]
 
-  spec.add_dependency "aitch", ">= 0.2.1"
-  spec.add_dependency "nokogiri"
-  spec.add_dependency "i18n"
-  spec.add_dependency "json"
+  spec.required_ruby_version = ">= 1.9.3"
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "autotest-standalone"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "fakeweb"
+  spec.add_runtime_dependency "aitch", "~> 0.2"
+  spec.add_runtime_dependency "nokogiri", "~> 1.6"
+  spec.add_runtime_dependency "i18n", "~> 0.7"
+  spec.add_runtime_dependency "json", "~> 1.8"
+
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "fakeweb", "~> 1.3"
+  spec.add_development_dependency "activesupport", "~> 4.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require "simplecov"
-SimpleCov.start
-
 require "bundler/setup"
 Bundler.require(:default, :development)
 


### PR DESCRIPTION
Remove warnings from gem build and remove unused gems.

Reference: http://guides.rubygems.org/specification-reference/

*TODO*

Maybe we can remove `rake` from gemspec and `Rakefile`, because it is a overkill *only* to call `rspec`.