### PR TITLE
Update PagSeguro::TransactionRequest create method.

### DIFF
--- a/lib/pagseguro/transaction_request.rb
+++ b/lib/pagseguro/transaction_request.rb
@@ -100,10 +100,7 @@ module PagSeguro
     # Return boolean.
     def create
       request = Request.post("transactions", api_version, params)
-      response = Response.new(request, self)
-      response.serialize
-
-      response.success?
+      Response.new(request, self).serialize
     end
 
     def update_attributes(attrs)

--- a/spec/pagseguro/features/create_transaction_request_spec.rb
+++ b/spec/pagseguro/features/create_transaction_request_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe "Creating Transaction Request" do
         status: [400, "Bad Request"], body: body, content_type: "text/xml"
     end
 
-    it "returns false" do
-      expect(transaction.create).to be_falsey
+    it "does not change attributes" do
+      expect { transaction.create }.not_to change { transaction.code }
     end
 
     describe "#errors" do

--- a/spec/pagseguro/transaction_request_spec.rb
+++ b/spec/pagseguro/transaction_request_spec.rb
@@ -92,7 +92,7 @@ describe PagSeguro::TransactionRequest do |variable|
       let(:raw_xml) { File.read("./spec/fixtures/transaction_request/success.xml") }
 
       it "creates a transaction request" do
-        expect(transaction_request.create).not_to be_a(PagSeguro::TransactionRequest)
+        expect(transaction_request.create).to be_a(PagSeguro::TransactionRequest)
         expect(transaction_request.code).to eq("9E884542-81B3-4419-9A75-BCC6FB495EF1")
       end
     end
@@ -120,8 +120,7 @@ describe PagSeguro::TransactionRequest do |variable|
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 
       it "does not create a transaction request" do
-        expect(transaction_request.create).to be_falsy
-        expect(transaction_request.code).to be_nil
+        expect { transaction_request.create }.not_to change { transaction_request.code }
       end
 
       it "add errors" do


### PR DESCRIPTION
This changes follows 2.2.0 standards of response, serializer, and related methods.