### PR TITLE
Update rspec syntax:

### DIFF
--- a/spec/pagseguro/authorization/collection_spec.rb
+++ b/spec/pagseguro/authorization/collection_spec.rb
@@ -42,8 +42,8 @@ describe PagSeguro::Authorization::Collection do
   end
 
   describe "method delegation" do
-    it { subject.respond_to? (:each) }
-    it { subject.respond_to? (:empty?) }
-    it { subject.respond_to? (:any?) }
+    it { is_expected.to respond_to(:each) }
+    it { is_expected.to respond_to(:empty?) }
+    it { is_expected.to respond_to(:any?) }
   end
 end

--- a/spec/pagseguro/payment_request_spec.rb
+++ b/spec/pagseguro/payment_request_spec.rb
@@ -76,7 +76,7 @@ describe PagSeguro::PaymentRequest do
 
   describe "#extra_params" do
     it "is empty before initialization" do
-      expect(subject.extra_params).to eql([])
+      expect(subject.extra_params).to be_empty
     end
 
     it "allows extra parameter addition" do

--- a/spec/pagseguro/transaction/search_spec.rb
+++ b/spec/pagseguro/transaction/search_spec.rb
@@ -66,19 +66,19 @@ describe PagSeguro::Search do
     context 'when there is a next page' do
       search = PagSeguro::Search.new('foo', 'bar', 0)
       it 'is page 0' do
-        expect(search.next_page?).to be_truthy
+        expect(search).to be_next_page
       end
 
       it 'is not page 0, but page < total_pages' do
         allow(search).to receive(:total_pages).and_return(3)
-        expect(search.next_page?).to be_truthy
+        expect(search).to be_next_page
       end
     end
 
     context 'when there is no next page' do
       it 'is not page 0, but page == total_pages' do
         allow(search).to receive(:total_pages).and_return(1)
-        expect(search.next_page?).to be_falsy
+        expect(search).not_to be_next_page
       end
     end
   end
@@ -86,11 +86,11 @@ describe PagSeguro::Search do
   describe '#previous_page?' do
     context 'when there is a previous page' do
       search = PagSeguro::Search.new('foo', 'bar', 2)
-      it { expect(search.previous_page?).to be_truthy }
+      it { expect(search).to be_previous_page }
     end
 
     context 'when there is no previous page' do
-      it { expect(search.previous_page?).to be_falsy }
+      it { expect(search).not_to be_previous_page }
     end
   end
 
@@ -124,12 +124,12 @@ describe PagSeguro::Search do
   describe '#valid?' do
     it 'is valid' do
       allow(search).to receive(:fetch).and_return(true)
-      expect(search.valid?).to be_truthy
+      expect(search).to be_valid
     end
 
     it "isn't valid" do
       allow(search).to receive(:fetch).and_return(false)
-      expect(search.valid?).to be_falsy
+      expect(search).not_to be_valid
     end
   end
 end

--- a/spec/pagseguro/transaction_request_spec.rb
+++ b/spec/pagseguro/transaction_request_spec.rb
@@ -57,7 +57,7 @@ describe PagSeguro::TransactionRequest do |variable|
 
   describe "#extra_params" do
     it "is empty before initialization" do
-      expect(subject.extra_params).to eql([])
+      expect(subject.extra_params).to be_empty
     end
 
     it "allows extra parameter addition" do


### PR DESCRIPTION
* Use `respond_to` matcher;
* Replace `eql([])` to `be_empty`;
* Use `be_something` syntax instead of `something?).to be_truthy`;