### PR TITLE
Cover all kind of errors

### DIFF
--- a/lib/pagseguro/errors.rb
+++ b/lib/pagseguro/errors.rb
@@ -20,17 +20,38 @@ module PagSeguro
 
     private
     def process(response)
-      @messages << error_message(:unauthorized, "Unauthorized") if response.unauthorized?
-      @messages << error_message(:forbidden, "Forbidden") if response.forbidden?
-      @messages << error_message(:not_found, "Not found") if response.not_found?
+      return unless response.error?
+      @messages << error_message(
+        error_to_sym(response.error),
+        error_to_human(response.error)
+      )
 
-      response.data.css("errors > error").each do |error|
-        @messages << error_message(error.css("code").text, error.css("message").text)
-      end if response.bad_request?
+      if response.error == Aitch::BadRequestError
+        response.data.css("errors > error").each do |error|
+          @messages << error_message(error.css("code").text, error.css("message").text)
+        end
+      end
     end
 
     def error_message(code, message)
       I18n.t(code, scope: "pagseguro.errors", default: message)
+    end
+
+
+    # Error formats
+    def error_to_sym(error)
+      error.to_s.split(/::/)[-1]
+        .gsub(/Error$/, '')
+        .gsub(/[[:upper:]]/)
+        .with_index {|k, i| i == 0 ? k : ('_' + k)}
+        .downcase
+        .to_sym
+    end
+
+    def error_to_human(error)
+      error_to_sym(error).to_s
+        .capitalize
+        .gsub('_', ' ')
     end
   end
 end

--- a/spec/pagseguro/errors_spec.rb
+++ b/spec/pagseguro/errors_spec.rb
@@ -6,10 +6,8 @@ describe PagSeguro::Errors do
   let(:http_response) do
     double(
       :http_response,
-      unauthorized?: true,
-      bad_request?: false,
-      not_found?: false,
-      forbidden?: false,
+      error?: true,
+      error: Aitch::UnauthorizedError
     )
   end
 
@@ -25,10 +23,8 @@ describe PagSeguro::Errors do
 
     before do
       allow(response).to receive_messages(
-        unauthorized?: true,
-        bad_request?: false,
-        not_found?: false,
-        forbidden?: false,
+        error?: true,
+        error: Aitch::UnauthorizedError
       )
       errors.add(http_response)
     end
@@ -42,10 +38,8 @@ describe PagSeguro::Errors do
 
     before do
       allow(response).to receive_messages(
-        unauthorized?: true,
-        bad_request?: false,
-        not_found?: true,
-        forbidden?: false
+        error?: true,
+        error: Aitch::NotFoundError
       )
       errors.add(http_response)
     end
@@ -59,10 +53,8 @@ describe PagSeguro::Errors do
 
     before do
       allow(response).to receive_messages(
-        unauthorized?: true,
-        bad_request?: false,
-        not_found?: false,
-        forbidden?: true
+        error?: true,
+        error: Aitch::ForbiddenError
       )
       errors.add(http_response)
     end
@@ -89,10 +81,8 @@ describe PagSeguro::Errors do
     before do
       allow(response).to receive_messages(
         data: xml,
-        unauthorized?: false,
-        bad_request?: true,
-        not_found?: true,
-        forbidden?: false
+        error?: true,
+        error: Aitch::BadRequestError
       )
     end
 
@@ -117,10 +107,8 @@ describe PagSeguro::Errors do
     before do
       allow(response).to receive_messages(
         data: xml,
-        unauthorized?: false,
-        bad_request?: true,
-        not_found?: false,
-        forbidden?: false
+        error?: true,
+        error: Aitch::BadRequestError
       )
     end
 
@@ -146,10 +134,8 @@ describe PagSeguro::Errors do
     before do
       allow(response).to receive_messages(
         data: xml,
-        unauthorized?: false,
-        bad_request?: true,
-        not_found?: true,
-        forbidden?: true
+        error?: true,
+        error: Aitch::BadRequestError
       )
       errors.add(http_response)
     end

--- a/spec/pagseguro/installment/response_spec.rb
+++ b/spec/pagseguro/installment/response_spec.rb
@@ -41,9 +41,8 @@ RSpec.describe PagSeguro::Installment::Response do
       before do
         allow(http_response).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
 

--- a/spec/pagseguro/installment_spec.rb
+++ b/spec/pagseguro/installment_spec.rb
@@ -35,8 +35,8 @@ describe PagSeguro::Installment do
       before do
         allow(request).to receive_messages(
           success?: false,
-          forbidden?: false,
-          bad_request?: true
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
 

--- a/spec/pagseguro/session/response_spec.rb
+++ b/spec/pagseguro/session/response_spec.rb
@@ -42,9 +42,8 @@ RSpec.describe PagSeguro::Session::Response do
       before do
         allow(http_response).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
 

--- a/spec/pagseguro/session_spec.rb
+++ b/spec/pagseguro/session_spec.rb
@@ -27,9 +27,8 @@ describe PagSeguro::Session do |variable|
       before do
         allow(request).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }

--- a/spec/pagseguro/transaction/response_spec.rb
+++ b/spec/pagseguro/transaction/response_spec.rb
@@ -40,9 +40,8 @@ describe PagSeguro::Transaction::Response do
       before do
         allow(http_response).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: true,
-          forbidden?: false,
+          error?: true,
+          error: Aitch::NotFoundError,
           body: raw_xml
         )
       end
@@ -83,9 +82,8 @@ describe PagSeguro::Transaction::Response do
       before do
         allow(http_response).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false,
+          error?: true,
+          error: Aitch::BadRequestError,
           body: raw_xml
         )
       end

--- a/spec/pagseguro/transaction/search_spec.rb
+++ b/spec/pagseguro/transaction/search_spec.rb
@@ -8,10 +8,8 @@ describe PagSeguro::Search do
     double(
       :response,
       data: xml,
-      unauthorized?: false,
-      bad_request?: false,
-      not_found?: false,
-      forbidden?: false
+      error?: false,
+      error: nil
     )
   end
 

--- a/spec/pagseguro/transaction_cancellation/response_spec.rb
+++ b/spec/pagseguro/transaction_cancellation/response_spec.rb
@@ -24,9 +24,12 @@ describe PagSeguro::TransactionCancellation::Response do
 
     context "when request fails" do
       before do
-        allow(http_response).to receive(:success?).and_return(false)
-        allow(http_response).to receive(:bad_request?).and_return(true)
-        allow(http_response).to receive(:body).and_return(raw_xml)
+        allow(http_response).to receive_messages(
+          success?: false,
+          error?: true,
+          error: Aitch::BadRequestError,
+          body: raw_xml
+        )
       end
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }
 

--- a/spec/pagseguro/transaction_cancellation_spec.rb
+++ b/spec/pagseguro/transaction_cancellation_spec.rb
@@ -37,9 +37,8 @@ describe PagSeguro::TransactionCancellation do
       before do
         allow(http_request).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
 

--- a/spec/pagseguro/transaction_refund_spec.rb
+++ b/spec/pagseguro/transaction_refund_spec.rb
@@ -47,10 +47,8 @@ describe PagSeguro::TransactionRefund do
         double(
           :ResponseRequest,
           success?: false,
-          unauthorized?: false,
-          not_found?: false,
-          bad_request?: true,
-          forbidden?: true,
+          error?: true,
+          error: Aitch::ForbiddenError,
           xml?: true,
           data: xml_parsed,
           body: raw_xml

--- a/spec/pagseguro/transaction_request/response_spec.rb
+++ b/spec/pagseguro/transaction_request/response_spec.rb
@@ -44,8 +44,8 @@ describe PagSeguro::TransactionRequest::Response do
       before do
         allow(http_response).to receive_messages(
           success?: false,
-          forbidden?: false,
-          bad_request?: true
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
 

--- a/spec/pagseguro/transaction_request_spec.rb
+++ b/spec/pagseguro/transaction_request_spec.rb
@@ -102,10 +102,9 @@ describe PagSeguro::TransactionRequest do |variable|
         double(
           :ResponseRequest,
           success?: false,
-          unauthorized?: false,
+          error?: true,
           bad_request?: true,
-          not_found?: false,
-          forbidden?: false,
+          error: Aitch::BadRequestError,
           xml?: true,
           data: xml_parsed,
           body: raw_xml

--- a/spec/pagseguro/transaction_spec.rb
+++ b/spec/pagseguro/transaction_spec.rb
@@ -50,9 +50,8 @@ describe PagSeguro::Transaction do
       before do
         allow(request).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
 
@@ -76,7 +75,7 @@ describe PagSeguro::Transaction do
     end
     let(:parsed_xml) { Nokogiri::XML(raw_xml) }
     let(:request) do
-      double(:Request, xml?: true, success?: true, unauthorized?: false,
+      double(:Request, xml?: true, success?: true, error?: false,
              bad_request?: false, body: raw_xml, data: parsed_xml)
     end
     subject { PagSeguro::Transaction.find_by_code("CODE") }
@@ -101,9 +100,8 @@ describe PagSeguro::Transaction do
       before do
         allow(request).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false
+          error?: true,
+          error: Aitch::BadRequestError
         )
       end
 
@@ -140,8 +138,7 @@ describe PagSeguro::Transaction do
     end
     let(:parsed_xml) { Nokogiri::XML(raw_xml) }
     let(:response) do
-      double(:Response, xml?: true, success?: true, unauthorized?: false,
-             bad_request?: false, body: raw_xml, data: parsed_xml)
+      double(:Response, xml?: true, success?: true, errors?: false, body: raw_xml, data: parsed_xml)
     end
     subject { PagSeguro::Transaction.find_status_history("CODE") }
 
@@ -165,9 +162,8 @@ describe PagSeguro::Transaction do
       before do
         allow(response).to receive_messages(
           success?: false,
-          bad_request?: true,
-          not_found?: false,
-          forbidden?: false
+          error?: true,
+          error: Aitch::NotFoundError
         )
       end
       let(:raw_xml) { File.read("./spec/fixtures/invalid_code.xml") }


### PR DESCRIPTION
This PR permit Error class catches all errors found by *#error?* Aitch method.
For to present the error info was created two methods to format the Aitch Error.
The `error_to_sym` method that convert the error exception to symbol and the `error_to_human` to convert the exception to human info.
The all specs related was updated.