### PR TITLE
Credentials on Serializer

### DIFF
--- a/lib/pagseguro/payment_request/serializer.rb
+++ b/lib/pagseguro/payment_request/serializer.rb
@@ -19,6 +19,7 @@ module PagSeguro
           data[:abandonURL] = payment_request.abandon_url
           data[:maxUses] = payment_request.max_uses
           data[:maxAge] = payment_request.max_age
+          data[:credentials] = payment_request.credentials
           payment_request.items.each_with_index do |item, index|
             serialize_item(data, item, index.succ)
           end


### PR DESCRIPTION
Add credentials in params to allow use credentials passed by method.

payment = PagSeguro::PaymentRequest.new
payment.credentials = PagSeguro::AccountCredentials.new('test-dannnylo@email.com', 'E280E0A9FFFA48A2AA9E4E73B5A6FC60')