### PR TITLE
Create base and manager class to collection

### DIFF
--- a/lib/pagseguro.rb
+++ b/lib/pagseguro.rb
@@ -10,6 +10,11 @@ require "pagseguro/extensions/mass_assignment"
 require "pagseguro/extensions/ensure_type"
 require "pagseguro/extensions/credentiable"
 
+require "pagseguro/collection_managers"
+require "pagseguro/collection_managers/generic_manager"
+require "pagseguro/collection_managers/items_manager"
+require "pagseguro/collection_base"
+
 require "pagseguro/version"
 require "pagseguro/config"
 

--- a/lib/pagseguro/collection_base.rb
+++ b/lib/pagseguro/collection_base.rb
@@ -1,0 +1,33 @@
+module PagSeguro
+  class CollectionBase
+    extend CollectionManagers::MacroMethods
+    extend Forwardable
+    include Enumerable
+
+    def_delegators :@store, :size, :clear, :empty?, :any?, :each, :include?
+
+    def initialize
+      @store = []
+    end
+
+    def collection_manager
+      CollectionManagers::GenericManager
+    end
+
+    def collection_type
+      eval singularize(self.class.to_s)
+    end
+
+    # Adds a new object to the collection.
+    def <<(param)
+      manager = collection_manager.new(collection_type)
+      manager.add(@store, param)
+    end
+
+    private
+
+    def singularize(string)
+      string.chars.to_a.slice(0...-1).join if string[-1] == 's'
+    end
+  end
+end

--- a/lib/pagseguro/collection_managers.rb
+++ b/lib/pagseguro/collection_managers.rb
@@ -1,0 +1,29 @@
+module PagSeguro
+  module CollectionManagers
+    module MacroMethods
+      def collection_type(klass)
+        define_method 'collection_type' do
+          self.class.classify(klass, PagSeguro)
+        end
+      end
+
+      def collection_manager(klass)
+        define_method 'collection_manager' do
+          self.class.classify(klass, CollectionManagers)
+        end
+      end
+
+      def camelize(param)
+        param.to_s.split('_').map(&:capitalize).join
+      end
+
+      def to_class(klass, super_klass)
+        super_klass.const_get( camelize(klass) )
+      end
+
+      def classify(klass, super_klass)
+        to_class(klass, super_klass)
+      end
+    end
+  end
+end

--- a/lib/pagseguro/collection_managers/generic_manager.rb
+++ b/lib/pagseguro/collection_managers/generic_manager.rb
@@ -1,0 +1,22 @@
+module PagSeguro
+  module CollectionManagers
+    class GenericManager
+      include Extensions::EnsureType
+
+      def initialize(collection_type)
+        @collection_type = collection_type
+      end
+
+      def add(store, param)
+        object = ensure_type(@collection_type, param)
+        store << object unless include?(store, object)
+      end
+
+      private
+
+      def include?(store, object)
+        store.detect { |stored_object| stored_object == object }
+      end
+    end
+  end
+end

--- a/lib/pagseguro/collection_managers/items_manager.rb
+++ b/lib/pagseguro/collection_managers/items_manager.rb
@@ -1,0 +1,33 @@
+module PagSeguro
+  module CollectionManagers
+    class ItemsManager
+      include Extensions::EnsureType
+
+      def initialize(collection_type)
+        @collection_type = collection_type
+      end
+
+      def add(store, param)
+        item = ensure_type(@collection_type, param)
+
+        original_item = include?(store, item)
+
+        if original_item
+          if item.quantity.nil?
+            original_item.quantity += 1
+          else
+            original_item.quantity += item.quantity
+          end
+        else
+          store << item
+        end
+      end
+
+      private
+
+      def include?(store, object)
+        store.detect { |stored_object| stored_object == object }
+      end
+    end
+  end
+end

--- a/lib/pagseguro/document.rb
+++ b/lib/pagseguro/document.rb
@@ -7,5 +7,9 @@ module PagSeguro
 
     # Set the value.
     attr_accessor :value
+
+    def ==(other)
+      type == other.type && value == other.value
+    end
   end
 end

--- a/lib/pagseguro/documents.rb
+++ b/lib/pagseguro/documents.rb
@@ -1,27 +1,5 @@
 module PagSeguro
-  class Documents
-    extend Forwardable
-    include Enumerable
-    include Extensions::EnsureType
-
-    def_delegators :@store, :size, :clear, :empty?, :any?, :each
-
-    def initialize
-      @store = []
-    end
-
-    # Adds a new document to document list.
-    def <<(document)
-      document = ensure_type(Document, document)
-      @store << document unless include?(document)
-    end
-
-    # Verify if the document is already included to document list.
-    # Returns boolean.
-    def include?(document)
-      @store.detect do |stored_document|
-        stored_document.type == document.type && stored_document.value == document.value
-      end
-    end
+  class Documents < CollectionBase
+    collection_type :document
   end
 end

--- a/lib/pagseguro/item.rb
+++ b/lib/pagseguro/item.rb
@@ -21,6 +21,10 @@ module PagSeguro
     # Set the shipping cost per unit.
     attr_accessor :shipping_cost
 
+    def ==(other)
+      id == other.id && description == other.description  && amount == other.amount
+    end
+
     private
     def before_initialize
       self.quantity = 1

--- a/lib/pagseguro/items.rb
+++ b/lib/pagseguro/items.rb
@@ -1,38 +1,5 @@
 module PagSeguro
-  class Items
-    extend Forwardable
-    include Enumerable
-    include Extensions::EnsureType
-
-    def_delegators :@store, :size, :clear, :empty?, :any?, :each
-
-    def initialize
-      @store = []
-    end
-
-    # Adds a new item to item list.
-    def <<(item)
-      item = ensure_type(Item, item)
-
-      original_item = include?(item)
-
-      if original_item
-        if item.quantity.nil?
-          original_item.quantity += 1
-        else
-          original_item.quantity += item.quantity
-        end
-      else
-        @store << item
-      end
-    end
-
-    # Verify if the item is already included to item list.
-    # Returns boolean.
-    def include?(item)
-      @store.detect do |stored_item|
-        stored_item.id == item.id && stored_item.description == item.description && stored_item.amount == item.amount
-      end
-    end
+  class Items < CollectionBase
+    collection_manager :items_manager
   end
 end

--- a/lib/pagseguro/phone.rb
+++ b/lib/pagseguro/phone.rb
@@ -12,5 +12,9 @@ module PagSeguro
     # Set the phone number.
     # Must have 7-9 numbers.
     attr_accessor :number
+
+    def ==(other)
+      type == other.type && area_code == other.area_code && number == other.number
+    end
   end
 end

--- a/lib/pagseguro/phones.rb
+++ b/lib/pagseguro/phones.rb
@@ -1,26 +1,4 @@
 module PagSeguro
-  class Phones
-    extend Forwardable
-    include Enumerable
-    include Extensions::EnsureType
-
-    def_delegators :@store, :size, :clear, :empty?, :any?, :each
-
-    def initialize
-      @store = []
-    end
-
-    def << (phone)
-      phone = ensure_type(Phone, phone)
-      @store << phone unless include?(phone)
-    end
-
-    def include?(phone)
-      @store.detect do |stored_phone|
-        stored_phone.type       == phone.type &&
-        stored_phone.number     == phone.number &&
-        stored_phone.area_code  == phone.area_code
-      end
-    end
+  class Phones < CollectionBase
   end
 end

--- a/spec/pagseguro/collection_managers/generic_manager_spec.rb
+++ b/spec/pagseguro/collection_managers/generic_manager_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe PagSeguro::CollectionManagers::GenericManager do
+  let(:collection_type) { PagSeguro::Phone }
+  let(:object_params) { {type: 'HOME', area_code: '11', number: '33114562'} }
+  let(:object) { PagSeguro::Phone.new(object_params) }
+  let(:store) { [] }
+
+  subject { described_class.new(collection_type) }
+
+  context 'when add object in collection' do
+    context 'ensures the object is kind of collection type' do
+      it 'when an object is given' do
+        subject.add(store, object)
+        expect(store.last).to be_a collection_type
+      end
+
+      it 'when an object params is given' do
+        subject.add(store, object_params)
+        expect(store.last).to be_a collection_type
+      end
+    end
+
+    it 'cannot include the same object' do
+      subject.add(store, object)
+      subject.add(store, object_params)
+
+      expect(store.size).to eq 1
+      expect(store.last).to eq object
+    end
+  end
+
+  it 'includes Extensions::EnsureType' do
+    expect(described_class.included_modules).to include PagSeguro::Extensions::EnsureType
+  end
+end

--- a/spec/pagseguro/documents_spec.rb
+++ b/spec/pagseguro/documents_spec.rb
@@ -1,28 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe PagSeguro::Documents do
-  [
-    :size,
-    :clear,
-    :empty?,
-    :any?,
-    :each,
-    :map
-  ].each do |method|
-    it { is_expected.to respond_to(method) }
-  end
-
-  it 'should initialize empty' do
-    expect(subject).to be_empty
-  end
+  it_behaves_like "Collection"
 
   context 'adding a new document' do
     let(:document) { { type: 'CPF', value: 11122233344 } }
-
-    it "shouldn't add the same document" do
-      subject << document
-      expect{ subject << document }.to_not change{ subject.size }
-    end
 
     context 'ensures type the new document' do
       it 'can be a hash' do

--- a/spec/pagseguro/items_spec.rb
+++ b/spec/pagseguro/items_spec.rb
@@ -1,60 +1,28 @@
 require "spec_helper"
 
 describe PagSeguro::Items do
-  it "implements #each" do
-    expect(PagSeguro::Items.new).to respond_to(:each)
-  end
+  it_behaves_like "Collection"
 
-  it "implements #any" do
-    expect(PagSeguro::Items.new).to respond_to(:any?)
-  end
-
-  it "includes Enumerable" do
-    expect(PagSeguro::Items.included_modules).to include(Enumerable)
-  end
-
-  it "sets item" do
-    item = PagSeguro::Item.new
-    items = PagSeguro::Items.new
-    items << item
-
-    expect(items.size).to eql(1)
-    expect(items).to include(item)
-  end
-
-  it "sets item from Hash" do
-    item = PagSeguro::Item.new(id: 1234)
-
-    expect(PagSeguro::Item)
-      .to receive(:new)
-      .with({id: 1234})
-      .and_return(item)
-
-    items = PagSeguro::Items.new
-    items << {id: 1234}
-
-    expect(items).to include(item)
-  end
-
-  it "empties items" do
-    items = PagSeguro::Items.new
-    items << {id: 1234}
-    items.clear
-
-    expect(items).to be_empty
-  end
-
-  context "#<<" do
+  context "adding a new item" do
     before do
       subject << item
     end
 
-    subject do
-      PagSeguro::Items.new
-    end
-
     let(:item) do
       PagSeguro::Item.new(id: 1234, description: "Tea", quantity: 1, amount: 300.0)
+    end
+
+    it "sets item" do
+      expect(subject.size).to eql(1)
+      expect(subject).to include(item)
+    end
+
+    it "sets item from Hash" do
+      item_hash = { id: 4321 }
+      subject << item_hash
+      item = PagSeguro::Item.new(item_hash)
+
+      expect(subject).to include(item)
     end
 
     context "when add same item" do

--- a/spec/pagseguro/phones_spec.rb
+++ b/spec/pagseguro/phones_spec.rb
@@ -1,28 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe PagSeguro::Phones do
-  [
-    :size,
-    :clear,
-    :empty?,
-    :any?,
-    :each,
-    :map
-  ].each do |method|
-    it { is_expected.to respond_to(method) }
-  end
-
-  it 'should initialize empty' do
-    expect(subject).to be_empty
-  end
+  it_behaves_like "Collection"
 
   context 'adding a new phone' do
     let(:phone) { { type: 'HOME', area_code: 11, number: 11112222 } }
-
-    it "shouldn't add the same phone" do
-      subject << phone
-      expect{ subject << phone }.to_not change{ subject.size }
-    end
 
     context 'ensures type the new phone' do
       it 'can be a hash' do

--- a/spec/support/shared_examples_for_collections.rb
+++ b/spec/support/shared_examples_for_collections.rb
@@ -1,0 +1,40 @@
+RSpec.shared_examples 'Collection' do
+  let(:object) { subject.collection_type.new }
+
+  it 'includes Enumerable' do
+    expect(described_class.included_modules).to include(Enumerable)
+  end
+
+  [
+    :size,
+    :clear,
+    :empty?,
+    :any?,
+    :each,
+    :map,
+    :include?
+  ].each do |method|
+    it { is_expected.to respond_to(method) }
+  end
+
+  it 'should initialize empty' do
+    expect(subject).to be_empty
+  end
+
+  it 'empties collection' do
+    subject << object
+    subject.clear
+
+    expect(subject).to be_empty
+  end
+
+  it 'should not add the same object' do
+    subject << object
+    expect{ subject << object }.to_not change{ subject.size }
+  end
+
+  it 'includes an added object' do
+    subject << object
+    expect(subject).to include object
+  end
+end


### PR DESCRIPTION

<img width="577" alt="screen shot 2016-02-04 at 1 46 12 pm" src="https://cloud.githubusercontent.com/assets/2837358/12822211/b5ab9f52-cb45-11e5-8e96-f520782b79bc.png">


### Create Collection Base Class

Used to provide a set of collections on PagSeguro and avoid duplication for classes with same purposes, like:

- Documents
- Phones
- Items

### Create Manager Classes

Used to handle behaviours about the Collections.

- **Create GenericManager**
  - The standard behaviour of the most of classes.

- **Create ItemsManager**
  - The specific logic to manipulate a item in the collection.
