### PR TITLE
Fixes split payment

### DIFF
--- a/examples/split_payment/create_transaction_using_boleto.rb
+++ b/examples/split_payment/create_transaction_using_boleto.rb
@@ -9,12 +9,12 @@ require_relative "../boot"
 payment = PagSeguro::BoletoTransactionRequest.new
 payment.notification_url = "http://www.example.com/notification"
 payment.payment_mode = "default"
-payment.credentials = PagSeguro::AccountCredentials.new("EMAIL", "TOKEN")
+payment.credentials = PagSeguro::ApplicationCredentials.new("APP_ID", "APP_KEY")
 
 payment.items << {
   id: 1234,
   description: %[Televisão 19" Sony],
-  amount: 459.50,
+  amount: 50.0,
   weight: 0
 }
 
@@ -43,12 +43,14 @@ payment.shipping = {
   }
 }
 
-payment.primary_receiver = 'primary.receiver@example.com'
-
 payment.receivers = [
   {
-    email: 'other.receiver@sandbox.pagseguro.com.br',
-    split: { amount: '400.00' }
+    public_key: 'PUBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    split: {
+      amount: 20.0,
+      rate_percent: 50.0,
+      fee_percent: 50.0
+    }
   }
 ]
 
@@ -88,6 +90,13 @@ else
     puts "      description: #{item.description}"
     puts "      quantity: #{item.quantity}"
     puts "      amount: #{item.amount.to_f}"
+  end
+
+  puts "    => Receivers"
+  puts "      receivers count: #{payment.receivers.size}"
+  payment.receivers.each do |receiver|
+    puts "      email: #{receiver.email}"
+    puts "      amount: #{receiver.split.amount}"
   end
 
   puts "    => Sender"

--- a/examples/split_payment/create_transaction_using_credit_card.rb
+++ b/examples/split_payment/create_transaction_using_credit_card.rb
@@ -9,12 +9,12 @@ require_relative "../boot"
 payment = PagSeguro::CreditCardTransactionRequest.new
 payment.notification_url = "http://example.com/notification"
 payment.payment_mode = "gateway"
-payment.credentials = PagSeguro::AccountCredentials.new("EMAIL", "TOKEN")
+payment.credentials = PagSeguro::ApplicationCredentials.new("APP_ID", "APP_KEY")
 
 payment.items << {
   id: 1234,
   description: %[Televisão 19" Sony],
-  amount: 459.50,
+  amount: 50.0,
   weight: 0
 }
 
@@ -43,12 +43,14 @@ payment.shipping = {
   }
 }
 
-payment.primary_receiver = 'primary.receiver@example.com'
-
 payment.receivers = [
   {
-    email: 'other.receiver@sandbox.pagseguro.com.br',
-    split: { amount: '400.00' }
+    public_key: 'PUBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    split: {
+      amount: 20.0,
+      rate_percent: 50.0,
+      fee_percent: 50.0
+    }
   }
 ]
 
@@ -117,6 +119,13 @@ else
     puts "      description: #{item.description}"
     puts "      quantity: #{item.quantity}"
     puts "      amount: #{item.amount.to_f}"
+  end
+
+  puts "    => Receivers"
+  puts "      receivers count: #{payment.receivers.size}"
+  payment.receivers.each do |receiver|
+    puts "      email: #{receiver.email}"
+    puts "      amount: #{receiver.split.amount}"
   end
 
   puts "    => Sender"

--- a/lib/pagseguro/request.rb
+++ b/lib/pagseguro/request.rb
@@ -38,9 +38,10 @@ module PagSeguro
     #
     def post_xml(path, api_version, credentials, data)
       credentials_params = credentials_to_params(credentials)
+      url_path = [api_version, path].reject(&:nil?).join('/')
 
       request.post do
-        url PagSeguro.api_url("#{api_version}/#{path}?#{credentials_params}")
+        url PagSeguro.api_url("#{url_path}?#{credentials_params}")
         headers "Content-Type" => "application/xml; charset=#{PagSeguro.encoding}"
         body data
       end

--- a/lib/pagseguro/transaction_request.rb
+++ b/lib/pagseguro/transaction_request.rb
@@ -109,7 +109,7 @@ module PagSeguro
       request = if receivers.empty?
                   Request.post('transactions', api_version, params)
                 else
-                  Request.post_xml('transactions', api_version, credentials, xml_params)
+                  Request.post_xml('transactions/', nil, credentials, xml_params)
                 end
 
       Response.new(request, self).serialize

--- a/lib/pagseguro/transaction_request/request_serializer.rb
+++ b/lib/pagseguro/transaction_request/request_serializer.rb
@@ -159,7 +159,7 @@ module PagSeguro
             xml.method_ transaction_request.payment_method
             xml.currency transaction_request.currency
             xml.notificationURL transaction_request.notification_url
-            xml.extraAmount transaction_request.extra_amount
+            xml.extraAmount to_amount(transaction_request.extra_amount || 0)
             xml.reference transaction_request.reference
 
             xml_serialize_sender(xml, transaction_request.sender)
@@ -294,9 +294,9 @@ module PagSeguro
             xml.send(:receiver) {
               xml.send(:publicKey, receiver.public_key)
               xml.send(:split) {
-                xml.send(:amount, receiver.split.amount)
-                xml.send(:ratePercent, receiver.split.rate_percent)
-                xml.send(:feePercent, receiver.split.fee_percent)
+                xml.send(:amount, to_amount(receiver.split.amount))
+                xml.send(:ratePercent, to_amount(receiver.split.rate_percent))
+                xml.send(:feePercent, to_amount(receiver.split.fee_percent))
               }
             }
           end

--- a/spec/pagseguro/transaction_request/request_serializer_spec.rb
+++ b/spec/pagseguro/transaction_request/request_serializer_spec.rb
@@ -26,9 +26,9 @@ describe PagSeguro::TransactionRequest::RequestSerializer do
           .*<receiver>
             .*<publicKey>PUB1234ABC</publicKey>
             .*<split>
-              .*<amount>10</amount>
-              .*<ratePercent>12</ratePercent>
-              .*<feePercent>11</feePercent>
+              .*<amount>10.00</amount>
+              .*<ratePercent>12.00</ratePercent>
+              .*<feePercent>11.00</feePercent>
         ]xm
     end
 
@@ -237,12 +237,21 @@ describe PagSeguro::TransactionRequest::RequestSerializer do
       end
     end
 
+    it 'should serialize empty extraAmount' do
+      transaction_request.extra_amount = nil
+
+      expect(xml).to match %r[
+      <payment>
+        .*<extraAmount>0.00</extraAmount>
+      ]xm
+    end
+
     it 'should serialize extraAmount' do
       transaction_request.extra_amount = 100
 
       expect(xml).to match %r[
       <payment>
-        .*<extraAmount>100</extraAmount>
+        .*<extraAmount>100.00</extraAmount>
       ]xm
     end
 


### PR DESCRIPTION
* Its url has no api version;
* The examples are using email instead of public_key;
* And these examples must use `ApplicationCredentials`;