### PR TITLE
Rename use of max_amount to max_amount_per_payment in examples of subscriptions

### DIFF
--- a/examples/subscription/create_auto_plan.rb
+++ b/examples/subscription/create_auto_plan.rb
@@ -12,7 +12,7 @@ plan = PagSeguro::SubscriptionPlan.new(
   name: 'Seguro contra roubo do Notebook',
   details: 'Taxa referente ao seguro contra roubo de Notebook',
   amount: 100.0,
-  max_amount: 2400.0,
+  max_amount_per_period: 2400.0,
   period: 'Monthly',
   final_date: Time.new(2017, 2, 28, 20, 20),
 

--- a/examples/subscription/create_manual_plan.rb
+++ b/examples/subscription/create_manual_plan.rb
@@ -11,7 +11,7 @@ plan = PagSeguro::SubscriptionPlan.new(
   name: 'Testing',
   charge: 'MANUAL', # Manual Subscription Plan must always use manual charge type.
   amount: 80.0,
-  max_amount: 35_000,
+  max_amount_per_payment: 35_000,
   max_amount_per_period: 100,
   final_date: Date.new(2017, 1, 1),
   membership_fee: 150.0,


### PR DESCRIPTION
The rename of this variable/attribute was introduced in 5d9cc4fe9c7d627a2af0c33a4ea500b623017b42 (#198).