### PR TITLE
Support cnpj on transparent checkout

### DIFF
--- a/lib/pagseguro/payment_request/request_serializer.rb
+++ b/lib/pagseguro/payment_request/request_serializer.rb
@@ -68,7 +68,8 @@ module PagSeguro
 
         data[:senderEmail] =  sender.email
         data[:senderName] = sender.name
-        data[:senderCPF] = sender.cpf
+        data[:senderCPF] = sender.cpf if sender.cpf
+        data[:senderCNPJ] = sender.cnpj if sender.cnpj
 
         serialize_phone(data, sender.phone)
       end

--- a/lib/pagseguro/sender.rb
+++ b/lib/pagseguro/sender.rb
@@ -23,6 +23,9 @@ module PagSeguro
 
     # Set the sender ip
     attr_accessor :ip
+    #
+    # Set the CNPJ document.
+    attr_accessor :cnpj
 
     # Set sender hash.
     # It's used to identify the sender.

--- a/lib/pagseguro/sender.rb
+++ b/lib/pagseguro/sender.rb
@@ -23,7 +23,7 @@ module PagSeguro
 
     # Set the sender ip
     attr_accessor :ip
-    #
+
     # Set the CNPJ document.
     attr_accessor :cnpj
 

--- a/lib/pagseguro/transaction_request/request_serializer.rb
+++ b/lib/pagseguro/transaction_request/request_serializer.rb
@@ -98,7 +98,8 @@ module PagSeguro
 
         params[:senderEmail] =  sender.email
         params[:senderName] = sender.name
-        params[:senderCPF] = sender.cpf
+        params[:senderCPF] = sender.cpf if sender.cpf
+        params[:senderCNPJ] = sender.cnpj if sender.cnpj
         params[:senderHash] = sender.hash
 
         serialize_sender_phone(sender.phone)
@@ -276,8 +277,11 @@ module PagSeguro
           xml_serialize_phone(xml, sender.phone)
 
           documents = [sender.document]
+
           if sender.cpf
             documents << PagSeguro::Document.new(type: 'CPF', value: sender.cpf)
+          elsif sender.cnpj
+            documents << PagSeguro::Document.new(type: 'CNPJ', value: sender.cnpj)
           end
 
           xml_serialize_documents(xml, documents)

--- a/spec/pagseguro/payment_request/request_serializer_spec.rb
+++ b/spec/pagseguro/payment_request/request_serializer_spec.rb
@@ -163,7 +163,7 @@ describe PagSeguro::PaymentRequest::RequestSerializer do
       it { expect(params).to include(shippingAddressComplement: "COMPLEMENT") }
     end
 
-    context "sender serialization" do
+    context "sender serialization with cpf" do
       before do
         sender = PagSeguro::Sender.new({
           email: "EMAIL",
@@ -177,6 +177,22 @@ describe PagSeguro::PaymentRequest::RequestSerializer do
       it { expect(params).to include(senderEmail: "EMAIL") }
       it { expect(params).to include(senderName: "NAME") }
       it { expect(params).to include(senderCPF: "CPF") }
+    end
+
+    context "sender serialization with cnpj" do
+      before do
+        sender = PagSeguro::Sender.new({
+          email: "EMAIL",
+          name: "NAME",
+          cnpj: "CNPJ"
+        })
+
+        allow(payment_request).to receive(:sender).and_return(sender)
+      end
+
+      it { expect(params).to include(senderEmail: "EMAIL") }
+      it { expect(params).to include(senderName: "NAME") }
+      it { expect(params).to include(senderCNPJ: "CNPJ") }
     end
 
     context "phone serialization" do

--- a/spec/pagseguro/sender_spec.rb
+++ b/spec/pagseguro/sender_spec.rb
@@ -4,6 +4,7 @@ describe PagSeguro::Sender do
   it_assigns_attribute :name
   it_assigns_attribute :email
   it_assigns_attribute :cpf
+  it_assigns_attribute :cnpj
   it_assigns_attribute :hash
   it_assigns_attribute :ip
 

--- a/spec/pagseguro/transaction_request/request_serializer_spec.rb
+++ b/spec/pagseguro/transaction_request/request_serializer_spec.rb
@@ -76,11 +76,9 @@ describe PagSeguro::TransactionRequest::RequestSerializer do
         end
       end
 
-      context 'when there is only another document' do
+      context 'when there is only cnpj' do
         before do
-          transaction_request.sender = {
-            document: { type: 'CNPJ', value: '62057673000135' }
-          }
+          transaction_request.sender = { cnpj: '62057673000135' }
         end
 
         it 'should render only the name' do
@@ -567,7 +565,7 @@ describe PagSeguro::TransactionRequest::RequestSerializer do
       it { expect(params).to include(billingAddressComplement: "COMPLEMENT") }
     end
 
-    context "sender serialization" do
+    context "sender serialization with CPF" do
       before do
         sender = PagSeguro::Sender.new({
           hash: "HASH",
@@ -587,6 +585,30 @@ describe PagSeguro::TransactionRequest::RequestSerializer do
       it { expect(params).to include(senderEmail: "EMAIL") }
       it { expect(params).to include(senderName: "NAME") }
       it { expect(params).to include(senderCPF: "CPF") }
+      it { expect(params).to include(senderAreaCode: "AREA_CODE") }
+      it { expect(params).to include(senderPhone: "NUMBER") }
+    end
+
+    context "sender serialization with CNPJ" do
+      before do
+        sender = PagSeguro::Sender.new({
+          hash: "HASH",
+          email: "EMAIL",
+          name: "NAME",
+          cnpj: "CNPJ",
+          phone: {
+            area_code: "AREA_CODE",
+            number: "NUMBER"
+          }
+        })
+
+        allow(transaction_request).to receive(:sender).and_return(sender)
+      end
+
+      it { expect(params).to include(senderHash: "HASH") }
+      it { expect(params).to include(senderEmail: "EMAIL") }
+      it { expect(params).to include(senderName: "NAME") }
+      it { expect(params).to include(senderCNPJ: "CNPJ") }
       it { expect(params).to include(senderAreaCode: "AREA_CODE") }
       it { expect(params).to include(senderPhone: "NUMBER") }
     end


### PR DESCRIPTION
In order to support Companies as a sender, this PR intends to support CNPJ document on transparent checkout and payment request.