### PR TITLE
Update version to 2.6 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
-## Next release - 2.5.0
+2.6.0
+
+- Assinatura
+- Adicionado arquivo de configuração docker e docker-compose
+- Atualização e refatoração de exemplos
+
+2.5.0
 
 - Atualizado a sintaxe do rspec
+- Cobertura de todos os tipos de erros http
+- Removido gems não usadas
+- Criado módulo de coleções
+- Adicionado parcelamento por receptor
+- Classe Refund renomeada para TransactionRefund
+- Requisição de autorização com conta existente ou sugestão de cadastro
 
 2.4.0
 

--- a/lib/pagseguro/version.rb
+++ b/lib/pagseguro/version.rb
@@ -1,3 +1,3 @@
 module PagSeguro
-  VERSION = "2.5.0"
+  VERSION = "2.6.0"
 end


### PR DESCRIPTION
I used these links to check the changes:

* [#188](https://github.com/pagseguro/ruby/pull/188) and;
* [https://github.com/pagseguro/ruby/compare/dev?expand=1](https://github.com/pagseguro/ruby/compare/dev?expand=1);