### PR TITLE
Update and fix manual subscription charging examples and related code:

### DIFF
--- a/examples/preapproval/charge_preapproval.rb
+++ b/examples/preapproval/charge_preapproval.rb
@@ -11,8 +11,8 @@ email = 'EMAIL'
 token = 'TOKEN'
 
 charger = PagSeguro::ManualSubscriptionCharger.new(
-  reference: 'REF12341',
-  subscription_code: '12E10BEF5E5EF94004313FB891C8E4CF',
+  reference: 'REFERENCE',
+  subscription_code: 'SUBSCRIPTION_CODE',
 )
 
 charger.items << {
@@ -29,7 +29,7 @@ charger.create
 
 if charger.errors.any?
   puts '=> ERRORS'
-  puts charger.errors.join('\n')
+  puts charger.errors.join("\n")
 else
   print '=> Subscription was corrected charged, the transaction code is '
   puts charger.transaction_code

--- a/examples/preapproval/create_preapproval_manual.rb
+++ b/examples/preapproval/create_preapproval_manual.rb
@@ -11,8 +11,9 @@ token = 'TOKEN'
 
 plan = PagSeguro::SubscriptionPlan.new(
   charge: 'manual', # Manual Subscription Plan must always use manual charge type.
-  redirect_url: 'http://example.com',
-  reference: 'REF-123',
+  redirect_url: 'http://www.lojateste.com.br/redirect',
+  review_url: 'http://www.lojateste.com.br/review',
+  reference: 'REFERENCE',
 
   sender: {
     name: 'Nome do Cliente',
@@ -33,11 +34,10 @@ plan = PagSeguro::SubscriptionPlan.new(
   name: 'Insurance',
   details: 'Payment of 100.',
   amount: 100.0,
-  max_amount_per_payment: 100.0,
   period: 'Monthly',
   max_payments_per_period: 2,
   max_amount_per_period: 200.0,
-  initial_date: Time.new(2017, 1, 1, 0, 0),
+  initial_date: Time.new(2016, 4, 19, 0, 0),
   final_date: Time.new(2017, 1, 1, 0, 0),
   max_total_amount: 2_400.0
 )

--- a/lib/pagseguro/subscription_plan/request_serializer.rb
+++ b/lib/pagseguro/subscription_plan/request_serializer.rb
@@ -65,7 +65,7 @@ module PagSeguro
               xml.send(:period, object.period)
               xml.send(:amountPerPayment, to_amount(object.amount))
               xml.send(:maxTotalAmount, to_amount(object.max_total_amount))
-              xml.send(:maxPaymentsPerPeriod, to_amount(object.max_payments_per_period))
+              xml.send(:maxPaymentsPerPeriod, object.max_payments_per_period.to_i)
               xml.send(:maxAmountPerPeriod, to_amount(object.max_amount_per_period))
               xml.send(:maxAmountPerPayment, to_amount(object.max_amount_per_payment))
               xml.send(:finalDate, object.final_date.xmlschema) if object.final_date

--- a/spec/pagseguro/subscription_plan/request_serializer_spec.rb
+++ b/spec/pagseguro/subscription_plan/request_serializer_spec.rb
@@ -95,6 +95,16 @@ describe PagSeguro::SubscriptionPlan::RequestSerializer do
         ]xm
     end
 
+    it 'should not use floating number to serializer max payments per period' do
+      plan.max_payments_per_period = 3
+
+      expect(subject.to_xml_params).not_to match %r[
+        <preApprovalRequest>
+          .*<preApproval>
+            .*<maxPaymentsPerPeriod>3.00
+        ]xm
+    end
+
     it 'should serializer max amount per period' do
       plan.max_amount_per_period = 300
 


### PR DESCRIPTION
* Use capitalized string to sample code;
* Use default pagseguro store url to review and redirect url;
* Fix to send maxPaymentsPerPeriod using integer, not float;