### PR TITLE
Fix serializer and examples of SubscriptionPlay.

### DIFF
--- a/examples/preapproval/create_preapproval_auto.rb
+++ b/examples/preapproval/create_preapproval_auto.rb
@@ -18,8 +18,8 @@ plan = PagSeguro::SubscriptionPlan.new(
   name: 'Seguro contra roubo do Notebook',
   details: 'Taxa referente ao seguro contra roubo de Notebook',
   period: 'Monthly',
-  initial_date: Time.new(2017, 2, 28, 1, 0),
   final_date: Time.new(2017, 2, 28, 20, 20),
+  amount: 100.0,
   max_total_amount: 2400.0,
 
   sender: {
@@ -46,7 +46,7 @@ plan.create
 
 if plan.errors.any?
   puts '=> ERRORS'
-  puts plan.errors.join('\n')
+  puts plan.errors.join("\n")
 else
   print '=> Subscription Plan correct created, its code is '
   puts plan.code

--- a/lib/pagseguro/subscription_plan/request_serializer.rb
+++ b/lib/pagseguro/subscription_plan/request_serializer.rb
@@ -65,7 +65,7 @@ module PagSeguro
               xml.send(:period, object.period)
               xml.send(:amountPerPayment, to_amount(object.amount))
               xml.send(:maxTotalAmount, to_amount(object.max_total_amount))
-              xml.send(:maxPaymentsPerPeriod, object.max_payments_per_period.to_i)
+              xml.send(:maxPaymentsPerPeriod, object.max_payments_per_period.to_i) if object.max_payments_per_period
               xml.send(:maxAmountPerPeriod, to_amount(object.max_amount_per_period))
               xml.send(:maxAmountPerPayment, to_amount(object.max_amount_per_payment))
               xml.send(:finalDate, object.final_date.xmlschema) if object.final_date

--- a/spec/pagseguro/subscription_plan/request_serializer_spec.rb
+++ b/spec/pagseguro/subscription_plan/request_serializer_spec.rb
@@ -85,6 +85,12 @@ describe PagSeguro::SubscriptionPlan::RequestSerializer do
         ]xm
     end
 
+    it 'should not serializer max payments per period if its value is nil' do
+      plan.max_payments_per_period = nil
+
+      expect(subject.to_xml_params).not_to match %r[.*<maxPaymentsPerPeriod>]xm
+    end
+
     it 'should serializer max payments per period' do
       plan.max_payments_per_period = 3
 


### PR DESCRIPTION
# 1

I'm fixing this response from server:

* [x] preApprovalMaxPaymentsPerPeriod out of range: 0
* [x] preApproval auto charged can not inform initialDate.
* [x] in preApproval auto charged the following parameters are required: amountPerPayment, period and finalDate.
* [x] preApproval auto charged can not inform maxPaymentsPerPeriod, maxAmountPerPayment or maxAmountPerPeriod.

# 2
This commit also reverts wrong information introduced at d983a3401abbcf8d11266e31416993dfc6284cf6.