### PR TITLE
Add authorizer_email to Authorization Response object

### DIFF
--- a/lib/pagseguro/authorization.rb
+++ b/lib/pagseguro/authorization.rb
@@ -15,6 +15,9 @@ module PagSeguro
     # The authorization permissions
     attr_accessor :permissions
 
+    # The authorization authorizerEmail
+    attr_accessor :authorizer_email
+
     # Find an authorization by it's notification code
     def self.find_by_notification_code(code, options = {})
       request = Request.get("authorizations/notifications/#{code}", api_version, options)

--- a/lib/pagseguro/authorization/response_serializer.rb
+++ b/lib/pagseguro/authorization/response_serializer.rb
@@ -18,6 +18,7 @@ module PagSeguro
         data[:code] = xml.css("> code").text
         data[:reference] = xml.css("reference").text
         data[:created_at] = Time.parse xml.css("creationDate").text
+        data[:authorizer_email] = xml.css("authorizerEmail").text
       end
 
       def serialize_permissions(data)


### PR DESCRIPTION
The authorizerEmail is not part of the Response object, but it's on the response XML data.

When implementing an integration using split-payments I needed the AuthorizerEmail that is returned in the response XML from https://ws.pagseguro.uol.com.br/v2/authorizations/notifications/.
The email will later be used as primary receiver to create a payment request:
https://github.com/pagseguro/ruby/blob/master/examples/split_payment/create_payment_request.rb
