### PR TITLE
Fix trial duration serialization

### DIFF
--- a/lib/pagseguro/subscription_plan/request_serializer.rb
+++ b/lib/pagseguro/subscription_plan/request_serializer.rb
@@ -71,7 +71,7 @@ module PagSeguro
               xml.send(:finalDate, object.final_date.xmlschema) if object.final_date
               xml.send(:initialDate, object.initial_date.xmlschema) if object.initial_date
               xml.send(:membershipFee, to_amount(object.membership_fee))
-              xml.send(:trialPeriodDuration, object.trial_duration.to_i)
+              xml.send(:trialPeriodDuration, object.trial_duration.to_i) if object.trial_duration
             }
           }
         end

--- a/spec/pagseguro/subscription_plan/request_serializer_spec.rb
+++ b/spec/pagseguro/subscription_plan/request_serializer_spec.rb
@@ -151,6 +151,12 @@ describe PagSeguro::SubscriptionPlan::RequestSerializer do
         ]xm
     end
 
+    it 'should not serializer trial duration if its value is nil' do
+      plan.trial_duration = nil
+
+      expect(subject.to_xml_params).not_to match %r[.*<trialPeriodDuration>]xm
+    end
+
     it 'should serializer trial duration' do
       plan.trial_duration = 30.0
 


### PR DESCRIPTION
Before this change, XML entity `<trialPeriodDuration>` is added to the request even if the object has no trial period, because `nil.to_i` is to 0, so Pagseguro returns message "Trial period duration is invalid."