### PR TITLE
Fixes transaction serializer operational_fee_amount BigDecimal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.6.1
+
+- Correção na serialização da transação
+
 2.6.0
 
 - Assinatura

--- a/lib/pagseguro/transaction/serializer.rb
+++ b/lib/pagseguro/transaction/serializer.rb
@@ -71,12 +71,16 @@ module PagSeguro
           intermediation_rate_amount: BigDecimal(xml.css("creditorFees > intermediationRateAmount").text),
           intermediation_fee_amount: BigDecimal(xml.css("creditorFees > intermediationFeeAmount").text),
           installment_fee_amount: BigDecimal(xml.css("creditorFees > installmentFeeAmount").text),
-          commission_fee_amount: BigDecimal(xml.css("creditorFees > commissionFeeAmount").text),
-          efrete: BigDecimal(xml.css("creditorFees > efrete").text)
         }
 
         operationalFeeAmount = xml.css("creditorFees > operationalFeeAmount").text
         data[:creditor_fees].merge!(operational_fee_amount: BigDecimal(operationalFeeAmount)) if operationalFeeAmount.present?
+
+        commissionFeeAmount = xml.css("creditorFees > commissionFeeAmount").text
+        data[:creditor_fees].merge!(commission_fee_amount: BigDecimal(commissionFeeAmount)) if commissionFeeAmount.present?
+
+        efrete = xml.css("creditorFees > efrete").text
+        data[:creditor_fees].merge!(efrete: BigDecimal(efrete)) if efrete.present?
       end
 
       def serialize_payments(data)

--- a/lib/pagseguro/transaction/serializer.rb
+++ b/lib/pagseguro/transaction/serializer.rb
@@ -71,10 +71,12 @@ module PagSeguro
           intermediation_rate_amount: BigDecimal(xml.css("creditorFees > intermediationRateAmount").text),
           intermediation_fee_amount: BigDecimal(xml.css("creditorFees > intermediationFeeAmount").text),
           installment_fee_amount: BigDecimal(xml.css("creditorFees > installmentFeeAmount").text),
-          operational_fee_amount: BigDecimal(xml.css("creditorFees > operationalFeeAmount").text),
           commission_fee_amount: BigDecimal(xml.css("creditorFees > commissionFeeAmount").text),
           efrete: BigDecimal(xml.css("creditorFees > efrete").text)
         }
+
+        operationalFeeAmount = xml.css("creditorFees > operationalFeeAmount").text
+        data[:creditor_fees].merge!(operational_fee_amount: BigDecimal(operationalFeeAmount)) if operationalFeeAmount.present?,
       end
 
       def serialize_payments(data)

--- a/lib/pagseguro/transaction/serializer.rb
+++ b/lib/pagseguro/transaction/serializer.rb
@@ -76,7 +76,7 @@ module PagSeguro
         }
 
         operationalFeeAmount = xml.css("creditorFees > operationalFeeAmount").text
-        data[:creditor_fees].merge!(operational_fee_amount: BigDecimal(operationalFeeAmount)) if operationalFeeAmount.present?,
+        data[:creditor_fees].merge!(operational_fee_amount: BigDecimal(operationalFeeAmount)) if operationalFeeAmount.present?
       end
 
       def serialize_payments(data)

--- a/lib/pagseguro/version.rb
+++ b/lib/pagseguro/version.rb
@@ -1,3 +1,3 @@
 module PagSeguro
-  VERSION = "2.6.0"
+  VERSION = "2.6.1"
 end

--- a/pagseguro-oficial.gemspec
+++ b/pagseguro-oficial.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary               = "Biblioteca de integração com o PagSeguro"
   spec.description           = "Biblioteca oficial de integração via API com o PagSeguro"
   spec.homepage              = "http://www.pagseguro.com.br"
-  spec.license               = "ASL"
+  spec.license               = "AAL"
 
   spec.files                 = `git ls-files`.split($/)
   spec.executables           = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Before this change, serializer tries to parse the XML entity <operational_fee_amount> but this entity doesn't exists at sandbox response.